### PR TITLE
Fix ring solver example

### DIFF
--- a/src/Algebra/Solver/Ring.idr
+++ b/src/Algebra/Solver/Ring.idr
@@ -286,11 +286,17 @@ namespace Eval
     ||| our code. For instance:
     |||
     ||| ```idris example
+    ||| isNeutral : (v : Bits8) -> Maybe (v === 0)
+    ||| isNeutral 0 = Just Refl
+    ||| isNeutral _ = Nothing
+    |||
+    ||| %ambiguity_depth 4
     ||| 0 binom1 : {x,y : Bits8}
     |||          -> (x + y) * (x + y) === x * x + 2 * x * y + y * y
-    ||| binom1 = solve [x,y]
+    ||| binom1 = solve {as = [x,y]}
+    |||                isNeutral
     |||                ((x .+. y) * (x .+. y))
-    |||                (x .*. x + 2 *. x *. y + y .*. y)
+    |||                (x .*. x + Lit 2 *. x *. y + y .*. y)
     ||| ```
     export
     0 solve :


### PR DESCRIPTION
I found the example on the ring solver was not working as is.
Since it took hours to make it work, I think it is worth updating.

It might be also helpful to mention that the operators on the type are different from the ones in the term.
At first, it was confusing to me and was not sure the operators in the type signature were supposed to be "normal" ones or `Expr` ones.

Nontheless, I found this library pretty cool.
Thanks for your work!